### PR TITLE
Fixed small bug in argument parsing

### DIFF
--- a/src/bsort.c
+++ b/src/bsort.c
@@ -254,6 +254,7 @@ main(int argc, char *argv[]) {
       break;
     case 'c':
       cut_off = atoi(optarg);
+      break;
     default:
       fprintf(stderr, "Invalid parameter: -%c\n", opt);
       goto failure;


### PR DESCRIPTION
A 'break' statement was missing in argument parsing.